### PR TITLE
Updated package.json to include new version of Gatsby.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
-    "gatsby": "^2.0.0",
+    "gatsby": "^2.0.33",
     "react": "^16.5.1",
     "react-dom": "^16.5.1"
   }


### PR DESCRIPTION
Based off of the issue here: https://github.com/gatsbyjs/gatsby/issues/9533

Updated the dependency to include the new version of Gatsby so the `TypeError: getNodesByType is not a function` error goes away. 

I chose the newest version of Gatsby but I am open to something a bit more stable.

Thanks!