### PR TITLE
update gatsby dependency to prevent develop/build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
-    "gatsby": "^2.0.33",
+    "gatsby": "^2.0.52",
     "react": "^16.5.1",
     "react-dom": "^16.5.1"
   }


### PR DESCRIPTION
This comment on the [issue](https://github.com/gatsbyjs/gatsby/issues/3183#issuecomment-440435838) and others similar on the repository led me to this pull request.
I've reproduced it going through the tutorial and so it happens that after this [step](https://www.gatsbyjs.org/tutorial/part-two/#installing-your-first-gatsby-plugin) the error starts to appear.
So in order to circunvent that and keep the issues light on the gatsby repository, this small fix.
