### PR TITLE
Add gatsby-link and gatsby-react-router-scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "gatsby": "^2.0.33",
+    "gatsby-link": "^2.0.7",
+    "gatsby-react-router-scroll": "^2.0.2",
     "react": "^16.5.1",
     "react-dom": "^16.5.1"
   }


### PR DESCRIPTION
### What is a change?
I just started with Gatsby project, and while following the [official docs](https://www.gatsbyjs.org/docs/) I got the below error.

![image](https://user-images.githubusercontent.com/13718176/49683361-58dcf600-fae9-11e8-95ed-222b3af0467c.png)

### How are we solving that?
It seems 2 deps are missing:
1. gatsby-link
2. gatsby-react-router-scroll

This PR adds these deps in `package.json`.

It addresses issue #30 
