### PR TITLE
Set exit status for default (unimplemented) test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
     "gatsby": "^2.16.1",


### PR DESCRIPTION
The current `npm test` command simply prints a message informing the user that they should write tests. The command exits with the default status of 0, indicating that the tests pass.

A default package.json (created using `npm init`) has similar behavior. The default test command prints `"Error: no test specified"`. However, it ends with a non-zero exit status, indicating failure. I believe that the default test command should exit with a status of 1, indicating failure, just like the default package.json.