### PR TITLE
Node 13.10.x babel-helper-compilation-targets version fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,9 +114,9 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz",
-      "integrity": "sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
+      "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
       "requires": {
         "@babel/compat-data": "^7.8.1",
         "browserslist": "^4.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,10 +118,10 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
       "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
       "requires": {
-        "@babel/compat-data": "^7.8.1",
-        "browserslist": "^4.8.2",
+        "@babel/compat-data": "^7.8.6",
+        "browserslist": "^4.9.1",
         "invariant": "^2.2.4",
-        "levenary": "^1.1.0",
+        "levenary": "^1.1.1",
         "semver": "^5.5.0"
       },
       "dependencies": {


### PR DESCRIPTION
ISSUE:
On node v13.10.x when using `gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world` as in the [tutorial](https://www.gatsbyjs.org/tutorial/part-zero/) of the official Gatsby page the following dependency `@babel/helper-compilation-targets` is locked in `package-lock.json` with the version `7.8.3`.

When trying to follow the run instructions we do:
`cd hello-world`
`gatsby develop`

and we are met with the following error:
```
ERROR #98123  WEBPACK

Generating SSR bundle failed

[BABEL] ~/gatsby-tests/test/.cache/develop-static-entry.js: No "exports" main resolved in ~/gatsby-tests/test/node_modules/@babel/helper-compilation-targets/package.json

File: .cache/develop-static-entry.js
```



As described in [this](https://github.com/babel/babel/issues/11216) `Babel` issue, to support latest node versions we can do an upgrade for version `7.8.4` and above of the `@babel/helper-compilation-targets` package.

This PR targets this precisely.