### PR TITLE
Update package.json gatsby to 2.24.42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,13 @@
         "browserslist": "^4.12.0",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@babel/core": {
@@ -57,6 +64,11 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -116,6 +128,13 @@
         "invariant": "^2.2.4",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -846,6 +865,13 @@
         "@babel/helper-plugin-utils": "^7.10.4",
         "resolve": "^1.8.1",
         "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -991,6 +1017,13 @@
         "invariant": "^2.2.2",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@babel/preset-modules": {
@@ -1206,11 +1239,11 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@graphql-tools/schema": {
-      "version": "6.0.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.0.17.tgz",
-      "integrity": "sha512-Fpuvsmc1hUF+dgebEYEQryRGj+HS0jdmVmXR4ojMT9mkwROdGtwH3G18zy15feNLe1k3hKp6HdS5TI8fUkwdKg==",
+      "version": "6.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.0.18.tgz",
+      "integrity": "sha512-xrScjRX9pTSVxqiSkx7Hn/9rzxLweysINa5Pkirdkv5lJY4e0Db53osur0nG/+SJyUmIN70tUtuhEZq4Ezr/PA==",
       "requires": {
-        "@graphql-tools/utils": "6.0.17",
+        "@graphql-tools/utils": "6.0.18",
         "tslib": "~2.0.0"
       },
       "dependencies": {
@@ -1222,9 +1255,9 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "6.0.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.0.17.tgz",
-      "integrity": "sha512-msV5a15fd6g5LnR+9EwrWin/OV0Ixy/dFkcXMLPmCVbh9cXtqVU9eqmLYxKRM8p4kXoBGlWAgibBaLhrSrLgjw==",
+      "version": "6.0.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.0.18.tgz",
+      "integrity": "sha512-8ntYuXJucBtjViOYljeKBzScfpVTnv7BfqIPU/WJ65h6nXD+qf8fMUR1C4MpCUeFvSjMiDSB5Z4enJmau/9D3A==",
       "requires": {
         "@ardatan/aggregate-error": "0.0.1",
         "camel-case": "4.1.1"
@@ -1407,6 +1440,11 @@
             "vfile-location": "^3.0.0",
             "xtend": "^4.0.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "unified": {
           "version": "9.0.0",
@@ -2016,11 +2054,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
     },
@@ -2480,13 +2513,14 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       },
       "dependencies": {
         "bn.js": {
@@ -4516,6 +4550,13 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "crypto-browserify": {
@@ -5300,9 +5341,9 @@
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -5326,9 +5367,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.529",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.529.tgz",
-      "integrity": "sha512-n3sriLldqNyjBlosbnPftjCY+m1dVOY307I1Y0HaHAqDGe3hRvK7ksJwWd+qs599ybR4jobCo1+7zXM9GyNMSA=="
+      "version": "1.3.532",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.532.tgz",
+      "integrity": "sha512-6PYzSCIa/Q2PImAHYLrvKPxuwFqDcvCzRT9w26Szd9psPa9et/t4TzgjaoX7wkBIfkhhgRQWwHWeUHOM4cJdRw=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -5898,9 +5939,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.5.tgz",
-      "integrity": "sha512-ajbJfHuFnpVNJjhyrfq+pH1C0gLc2y94OiCbAXT5O0J0YCKaFEHDV8+3+mDOr+w8WguRX+vSs1bM2BDG0VLvCw==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz",
+      "integrity": "sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==",
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flatmap": "^1.2.3",
@@ -6847,9 +6888,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.24.41",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.24.41.tgz",
-      "integrity": "sha512-sEr/eiJKl9MQudgpOyBMgLDvUoZbQO3zIunn4+nSzkBEdDFrSDLNdUVuX3ojQV5230eA2phhARygFrgGjk9Crg==",
+      "version": "2.24.47",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.24.47.tgz",
+      "integrity": "sha512-+LLqdKqfVGpk0GyKMaWMnCqonVUyumg7a5fhODdZbDELmcNsQKtO5HShKs8ZbMm1PIIHewmU3uRlqRZygfAD6w==",
       "requires": {
         "@babel/code-frame": "^7.10.3",
         "@babel/core": "^7.10.3",
@@ -6912,15 +6953,15 @@
         "find-cache-dir": "^3.3.1",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.12.82",
+        "gatsby-cli": "^2.12.87",
         "gatsby-core-utils": "^1.3.15",
         "gatsby-graphiql-explorer": "^0.4.12",
         "gatsby-legacy-polyfills": "^0.0.2",
         "gatsby-link": "^2.4.13",
-        "gatsby-plugin-page-creator": "^2.3.21",
+        "gatsby-plugin-page-creator": "^2.3.22",
         "gatsby-plugin-typescript": "^2.4.18",
         "gatsby-react-router-scroll": "^3.0.12",
-        "gatsby-telemetry": "^1.3.26",
+        "gatsby-telemetry": "^1.3.27",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.6.0",
@@ -6966,7 +7007,7 @@
         "react-refresh": "^0.7.0",
         "redux": "^4.0.5",
         "redux-thunk": "^2.3.0",
-        "semver": "^5.7.1",
+        "semver": "^7.3.2",
         "shallow-compare": "^1.2.2",
         "signal-exit": "^3.0.3",
         "slugify": "^1.4.4",
@@ -7001,9 +7042,9 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "gatsby-cli": {
-          "version": "2.12.82",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.12.82.tgz",
-          "integrity": "sha512-KB+aHONL5FDlzCAxeP/ySklFlqsqpRDo/CotYymKSRP/mBRiPLTUqGsiMx6PRjS8df1kweX4mZ+BcPu3pKn3sA==",
+          "version": "2.12.87",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.12.87.tgz",
+          "integrity": "sha512-LB65Hh8hN/H5XSh6EnOnK1jpUiB9GqgaW9c4SeGayogenaWk2RAY4blkq7ncVunM5Nm+uKbY9bDM9TlFe+r2Bg==",
           "requires": {
             "@babel/code-frame": "^7.10.3",
             "@hapi/joi": "^15.1.1",
@@ -7019,8 +7060,8 @@
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
             "gatsby-core-utils": "^1.3.15",
-            "gatsby-recipes": "^0.2.12",
-            "gatsby-telemetry": "^1.3.26",
+            "gatsby-recipes": "^0.2.16",
+            "gatsby-telemetry": "^1.3.27",
             "hosted-git-info": "^3.0.4",
             "ink": "^2.7.1",
             "ink-spinner": "^3.1.0",
@@ -7035,7 +7076,7 @@
             "react": "^16.8.0",
             "redux": "^4.0.5",
             "resolve-cwd": "^3.0.0",
-            "semver": "^6.3.0",
+            "semver": "^7.3.2",
             "signal-exit": "^3.0.3",
             "source-map": "0.7.3",
             "stack-trace": "^0.0.10",
@@ -7044,13 +7085,6 @@
             "uuid": "3.4.0",
             "yargs": "^15.3.1",
             "yurnalist": "^1.1.2"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
           }
         },
         "hosted-git-info": {
@@ -7185,9 +7219,9 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.3.21",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.3.21.tgz",
-      "integrity": "sha512-DlkKW6UOfM6sap2vyqwcEfkECugYblaa5t7oNBydU7U2rR7bAFyZCfuwPMfMhDrYwWnTtY0pH8q2Yz+tT9aAOg==",
+      "version": "2.3.22",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.3.22.tgz",
+      "integrity": "sha512-XG3uZh/1uqsT/cpp/Oy7l15MR3yF6RqG/Mf4Vk0iYRZn6poveIh8Pw4nhPekwbrn8TGT7Fp/dv1Npkvs/E2kqw==",
       "requires": {
         "@babel/traverse": "^7.10.2",
         "fs-exists-cached": "^1.0.0",
@@ -7236,9 +7270,9 @@
       }
     },
     "gatsby-recipes": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/gatsby-recipes/-/gatsby-recipes-0.2.12.tgz",
-      "integrity": "sha512-lvZzxqk2gqmFJipb5liCeVGbRRT1H4OOaLsJ9dT1TgbSrf1YnpvvfEEaJuOnm/prHs1oOlEdf14ZooA5OxhJeA==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/gatsby-recipes/-/gatsby-recipes-0.2.16.tgz",
+      "integrity": "sha512-Aq3zeg0kmzKlqiQWoONMz3cf/QdP/AjUEGNdUhEKyvwgd0d7K9may99ltrzcssLfhkLtv/+aPJllhQG//RQxqQ==",
       "requires": {
         "@babel/core": "^7.9.6",
         "@babel/generator": "^7.9.6",
@@ -7277,7 +7311,7 @@
         "fs-extra": "^8.1.0",
         "gatsby-core-utils": "^1.3.15",
         "gatsby-interface": "^0.0.166",
-        "gatsby-telemetry": "^1.3.26",
+        "gatsby-telemetry": "^1.3.27",
         "glob": "^7.1.6",
         "graphql": "^14.6.0",
         "graphql-compose": "^6.3.8",
@@ -7290,6 +7324,7 @@
         "is-url": "^1.2.4",
         "isomorphic-fetch": "^2.1.0",
         "jest-diff": "^25.5.0",
+        "lock": "^1.0.0",
         "lodash": "^4.17.15",
         "mitt": "^1.2.0",
         "mkdirp": "^0.5.1",
@@ -7450,11 +7485,6 @@
             "find-up": "^4.0.0"
           }
         },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-        },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7492,9 +7522,9 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.3.26",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.3.26.tgz",
-      "integrity": "sha512-10DqlSw0mvuRcQfoYmYdt+XAZqECqCUY8wYWo1Vpg3BwSpRtaW2rFjDqPa+MZSB5qfBfL92urDw8g1uZZolBNQ==",
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.3.27.tgz",
+      "integrity": "sha512-cX3+6dB3Tc6KYebYjVL0DGBvlnlJ43whmkVDKlcsSHyOKMkQBaCD4cKav3Im6iFa3jhmj5Z2MH20oPC26tHSTQ==",
       "requires": {
         "@babel/code-frame": "^7.10.3",
         "@babel/runtime": "^7.10.3",
@@ -9699,6 +9729,11 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
+      "integrity": "sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU="
+    },
     "lockfile": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
@@ -9921,6 +9956,13 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "map-cache": {
@@ -10507,6 +10549,13 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "normalize-path": {
@@ -10940,13 +10989,12 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "requires": {
-        "asn1.js": "^4.0.0",
+        "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
@@ -12829,6 +12877,11 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -13175,9 +13228,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -13242,9 +13295,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -14391,15 +14444,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-      "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^3.1.0",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
-    "gatsby": "^2.24.41",
+    "gatsby": "^2.24.42",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },


### PR DESCRIPTION
This brings gatsby to current release and eliminates `Error in "/home/jcastle/Development/DevCode/gatsby-starter-hello-world/node_modules/gatsby-plugin-page-creator/gatsby-node.js": Cannot find module 'gatsby-cli/lib/reporter'` when running `gatsby develop`.