### PR TITLE
Added the pnpm files for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+# PNPM files
+.pnpm-debug.lock


### PR DESCRIPTION
PNPM is a better alternative to npm that uses symlinks instead of downloading the packages multiple times. PNPM creates a debug lock file that takes up space and should be git ignored.